### PR TITLE
Fix a small bug

### DIFF
--- a/src/WolfDen133/WFT/API.php
+++ b/src/WolfDen133/WFT/API.php
@@ -30,7 +30,7 @@ class API {
 
         $config->set("name", $floatingText->getName());
         $config->set("lines", explode("#", $floatingText->getText()));
-        $config->set("world", $floatingText->getPosition()->getWorld()->getDisplayName());
+        $config->set("world", $floatingText->getPosition()->getWorld()->getFolderName());
         $config->set("x", $floatingText->getPosition()->getX());
         $config->set("y", $floatingText->getPosition()->getY());
         $config->set("z", $floatingText->getPosition()->getZ());


### PR DESCRIPTION
getByName( ) fetches the world by the folder name instead of display name. SO when the FloatingText is saved, the folder name should be saved and not the display name.

The display name and folder name aren't always the same. If that's the case the server crashes. 
`Position world is null or has been unloaded`



